### PR TITLE
feature/zms-38 updates

### DIFF
--- a/src/java/com/zimbra/cs/nginx/NginxLookupExtension.java
+++ b/src/java/com/zimbra/cs/nginx/NginxLookupExtension.java
@@ -1046,7 +1046,9 @@ public class NginxLookupExtension implements ZimbraExtension {
                         if (doDnsLookup) {
                             upstreamHost = this.getIPByIPMode(upstreamHost).getHostAddress();
                         }
-                        String upstreamPort = req.proto.equals(IMAP) ? imapServer.getImapBindPortAsString() : imapServer.getImapSSLBindPortAsString();
+                        String upstreamPort = req.proto.equals(IMAP) ?
+                                imapServer.getRemoteImapBindPortAsString() :
+                                imapServer.getRemoteImapSSLBindPortAsString();
                         DomainExternalRouteInfo domain = getDomainExternalRouteInfo(zlc, config, authUserWithRealDomainName);
                         boolean extRouteIncludeOrigAuthuser = domain == null ?
                                 prov.getDefaultDomain().isReverseProxyExternalRouteIncludeOriginalAuthusername() :


### PR DESCRIPTION
## zm-nginx-lookup-store

When the system is configured such that the list of IMAP servers in `zimbraReverseProxyUpstreamImapServers` is non-empty, the NLE will choose a server from that list.  The IMAP(S) servers that are managed by _zimbra-imap_ bind to different back-end ports than IMAP(S) servers being run inside of _mailboxd_.  The following LDAP attributes define the appropriate bind ports:

* `zimbraRemoteImapBindPort`
* `zimbraRemoteImapSSLBindPort`

This PR allows the NLE to choose the appropriate port number when constructing the URL that is returned to _nginx_.

Please also see related pull requests for:

* `zm-zcs-lib`
* `zm-mailbox`
* `zm-core-utils`
* `zm-build`
