### PR TITLE
ZCS-2402 update upstream imap server lookup

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -10,6 +10,27 @@
   <dependency org="commons-httpclient" name="commons-httpclient" rev="3.1" />
   <dependency org="commons-logging" name="commons-logging" rev="1.0" />
   <dependency org="commons-net" name="commons-net" rev="3.3" />
+  <dependency org="org.javassist" name="javassist" rev="3.22.0-CR2" />
+  <dependency org="org.objenesis" name="objenesis" rev="2.6" />
+  <dependency org="org.json" name="json" rev="20090211" />
+  <dependency org="cglib" name="cglib" rev="3.2.5"/>
+  <dependency org="asm" name="asm" rev="3.3.1"/>
+  <dependency org="dom4j" name="dom4j" rev="1.6.1"/>
+  <dependency org="log4j" name="log4j" rev="1.2.17"/>
+  <dependency org="com.google.guava" name="guava" rev="13.0.1" />
+  <dependency org="com.unboundid" name="unboundid-ldapsdk" rev="4.0.0"/>
+  <dependency org="org.easymock" name="easymock" rev="3.4" />
+  <dependency org="org.powermock" name="powermock-core" rev="1.7.1" />
+  <dependency org="org.powermock" name="powermock-api-mockito" rev="1.7.1" />
+  <dependency org="org.powermock" name="powermock-api-mockito2" rev="1.7.1" />
+  <dependency org="org.powermock" name="powermock-api-easymock" rev="1.7.1" />
+  <dependency org="org.powermock" name="powermock-module-junit4" rev="1.7.1" />
+  <dependency org="org.powermock" name="powermock-module-junit4-common" rev="1.7.1" />
+  <dependency org="org.powermock" name="powermock-api-support" rev="1.7.1" />
+  <dependency org="org.powermock" name="powermock-reflect" rev="1.7.1" />
+  <dependency org="org.mockito" name="mockito-core" rev="2.8.47" />
+  <dependency org="org.javassist" name="javassist" rev="3.18.2-GA" />
+  <!-- copy dependencies from zm-mailbox/store -->
   <dependency org="zimbra" name="zm-client" rev="latest.integration" />
   <dependency org="zimbra" name="zm-common" rev="latest.integration" />
   <dependency org="zimbra" name="zm-soap" rev="latest.integration" />

--- a/src/java-test/com/zimbra/cs/account/UnitTestAccount.java
+++ b/src/java-test/com/zimbra/cs/account/UnitTestAccount.java
@@ -1,0 +1,15 @@
+package com.zimbra.cs.account;
+
+public class UnitTestAccount extends Account {
+    private Server server = null;
+
+    public UnitTestAccount(String name, Provisioning prov, Server server) {
+        super(name, null, null, null, prov);
+        this.server = server;
+    }
+
+    @Override
+    public Server getServer() {
+        return server;
+    }
+}

--- a/src/java-test/com/zimbra/cs/account/UnitTestServer.java
+++ b/src/java-test/com/zimbra/cs/account/UnitTestServer.java
@@ -1,0 +1,29 @@
+package com.zimbra.cs.account;
+
+import com.zimbra.cs.account.Server;
+
+public class UnitTestServer extends Server {
+    private String[] reverseProxyUpstreamImapServers = null;
+    private String hostname = null;
+
+    public UnitTestServer (String[] reverseProxyUpstreamImapServers, String hostname,  Provisioning prov){
+        super(hostname, null, null, null, prov);
+        this.reverseProxyUpstreamImapServers = reverseProxyUpstreamImapServers;
+        this.hostname = hostname;
+    }
+
+    @Override
+    public String[] getReverseProxyUpstreamImapServers() {
+        return reverseProxyUpstreamImapServers;
+    }
+
+    @Override
+    public String getServiceHostname() {
+        return this.hostname;
+    }
+
+    public String toString()
+    {
+        return "UnitTestServer(" + this.hostname + ")";
+    }
+}

--- a/src/java-test/com/zimbra/qa/unittest/NginxLookupExtensionTest.java
+++ b/src/java-test/com/zimbra/qa/unittest/NginxLookupExtensionTest.java
@@ -1,0 +1,186 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2017 Zimbra, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <http://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.qa.unittest;
+
+import com.zimbra.common.account.Key;
+import com.zimbra.cs.account.*;
+import com.zimbra.cs.account.Config;
+import com.zimbra.cs.account.Entry;
+import com.zimbra.cs.account.ldap.LdapProv;
+import com.zimbra.cs.account.ldap.LdapProvisioning;
+import com.zimbra.cs.imap.ImapLoadBalancingMechanism;
+import com.zimbra.cs.nginx.NginxLookupExtension;
+import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.easymock.EasyMock;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.util.HashMap;
+import javax.servlet.http.HttpServletRequest;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Account.class, AttributeManager.class, Config.class, Entry.class, HttpServletRequest.class,
+        LdapProv.class, LdapProvisioning.class,
+        NginxLookupExtension.NginxLookupHandler.class,
+        NginxLookupExtension.NginxLookupRequest.class,
+        Provisioning.class, Server.class, UnitTestServer.class, UnitTestAccount.class})
+public class NginxLookupExtensionTest extends TestCase {
+
+    private static final String USER = "testnginxlookupextension-user1";
+
+    private static String DEFAULT_DOMAIN = "NginxLookupExtensionTest.local";
+
+    private static String QUSER = USER + "@" +DEFAULT_DOMAIN;
+
+    @Mock HttpServletRequest mockServletReq;
+
+    NginxLookupExtension.NginxLookupHandler handler;
+
+    Config config;
+
+    @Before
+    public void setUp() throws Exception {
+        config = Whitebox.newInstance(Config.class);
+        Whitebox.setInternalState(config, "mAttrs", new HashMap<>());
+        mockServletReq = PowerMock.createMock(HttpServletRequest.class);
+        handler = Whitebox.newInstance(NginxLookupExtension.NginxLookupHandler.class);
+        PowerMock.resetAll();
+    }
+
+    @Test
+    public void testLookupUpstreamImapServerNoAccount() throws Exception {
+        LdapProvisioning mockProvisioning = PowerMock.createMock(LdapProvisioning.class);
+        EasyMock.expect(mockProvisioning.get(Key.AccountBy.name, QUSER)).andReturn(null);
+        EasyMock.expect(mockProvisioning.getConfig()).andReturn(config).anyTimes();
+
+        Provisioning.setInstance(mockProvisioning);
+        PowerMock.mockStatic(Provisioning.class);
+
+        handler = Whitebox.newInstance(NginxLookupExtension.NginxLookupHandler.class);
+        Whitebox.setInternalState(handler, "prov", mockProvisioning);
+
+        PowerMock.mockStatic(ImapLoadBalancingMechanism.class);
+        PowerMock.suppress(PowerMock.constructor(ImapLoadBalancingMechanism.class));
+
+        AttributeManager mockAttributeManager = PowerMock.createMock(AttributeManager.class);
+        EasyMock.expect(mockAttributeManager.isEphemeral("zimbraImapLoadBalancingAlgorithm")).andReturn(false);
+        EasyMock.expect(mockAttributeManager.getAttributeInfo("zimbraImapLoadBalancingAlgorithm")).andReturn(null);
+
+        Whitebox.setInternalState(config, "mAttrMgr", mockAttributeManager);
+
+        NginxLookupExtension.NginxLookupRequest request = Whitebox.newInstance(NginxLookupExtension.NginxLookupRequest.class);
+        Whitebox.setInternalState(request, "user", QUSER);
+        Whitebox.setInternalState(request, "httpReq", mockServletReq);
+
+        PowerMock.replayAll();
+
+        Server server = Whitebox.invokeMethod(handler, "lookupUpstreamImapServer", request);
+        assertEquals("Server objects should be null", null, server);
+        PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testLookupUpstreamImapServerNoUpstreamServers() throws Exception {
+        Account account = Whitebox.newInstance(UnitTestAccount.class);
+
+        LdapProvisioning mockProvisioning = PowerMock.createMock(LdapProvisioning.class);
+        EasyMock.expect(mockProvisioning.get(Key.AccountBy.name, QUSER)).andReturn(account);
+        EasyMock.expect(mockProvisioning.getConfig()).andReturn(config).anyTimes();
+        Whitebox.setInternalState(handler, "prov", mockProvisioning);
+
+        Provisioning.setInstance(mockProvisioning);
+        PowerMock.mockStatic(Provisioning.class);
+
+        PowerMockito.suppress(PowerMockito.constructor(Server.class));
+        /*ImapLoadBalancingMechanism mockLBMech = PowerMock.createMock(ImapLoadBalancingMechanism.class);
+        PowerMockito.stub(PowerMockito.method(ImapLoadBalancingMechanism.class, "newInstance")).toReturn(mockLBMech);
+        EasyMock.expect(ImapLoadBalancingMechanism.newInstance()).andStubReturn(mockLBMech);
+        */
+        String[] servers = {};
+
+        Server testServer = Whitebox.newInstance(UnitTestServer.class);
+        Whitebox.setInternalState(testServer, "reverseProxyUpstreamImapServers", servers);
+        Whitebox.setInternalState(testServer, "hostname", DEFAULT_DOMAIN);
+        Whitebox.setInternalState(account, "server", testServer);
+        EasyMock.expect(mockProvisioning.getServerByServiceHostname(DEFAULT_DOMAIN)).andReturn(testServer);
+
+        AttributeManager mockAttributeManager = PowerMock.createMock(AttributeManager.class);
+        EasyMock.expect(mockAttributeManager.isEphemeral("zimbraImapLoadBalancingAlgorithm")).andReturn(false).anyTimes();
+        EasyMock.expect(mockAttributeManager.getAttributeInfo("zimbraImapLoadBalancingAlgorithm")).andReturn(null).anyTimes();
+        Whitebox.setInternalState(config, "mAttrMgr", mockAttributeManager);
+
+        NginxLookupExtension.NginxLookupRequest request = Whitebox.newInstance(NginxLookupExtension.NginxLookupRequest.class);
+        Whitebox.setInternalState(request, "user", QUSER);
+        Whitebox.setInternalState(request, "httpReq", mockServletReq);
+        EasyMock.expect(mockServletReq.getHeader("Client-IP")).andReturn("127.0.0.1").anyTimes();
+
+        PowerMock.replayAll();
+
+        Server server = Whitebox.invokeMethod(handler, "lookupUpstreamImapServer", request);
+        assertEquals("Server objects should be the same", testServer, server);
+
+        PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testLookupUpstreamImapServerUpstreamServers() throws Exception {
+        String[] servers = {DEFAULT_DOMAIN};
+        Server testServer = Whitebox.newInstance(UnitTestServer.class);
+        LdapProvisioning mockProvisioning = PowerMock.createMock(LdapProvisioning.class);
+        UnitTestAccount account = Whitebox.newInstance(UnitTestAccount.class);
+        EasyMock.expect(mockProvisioning.get(Key.AccountBy.name, QUSER)).andReturn(account);
+        EasyMock.expect(mockProvisioning.getServerByServiceHostname(DEFAULT_DOMAIN)).andReturn(testServer);
+        EasyMock.expect(mockProvisioning.getConfig()).andReturn(config).anyTimes();
+
+        Provisioning.setInstance(mockProvisioning);
+        PowerMock.mockStatic(Provisioning.class);
+
+        Whitebox.setInternalState(testServer, "reverseProxyUpstreamImapServers", servers);
+        Whitebox.setInternalState(testServer, "hostname", DEFAULT_DOMAIN);
+        Whitebox.setInternalState(account, "server", testServer);
+
+        NginxLookupExtension.NginxLookupRequest mockRequest = Whitebox.newInstance(NginxLookupExtension.NginxLookupRequest.class);
+        Whitebox.setInternalState(mockRequest, "user", QUSER);
+        Whitebox.setInternalState(mockRequest, "httpReq", mockServletReq);
+        NginxLookupExtension.NginxLookupHandler mockHandler = Whitebox.newInstance(NginxLookupExtension.NginxLookupHandler.class);
+        Whitebox.setInternalState(mockHandler, "prov", mockProvisioning);
+
+        EasyMock.expect(mockServletReq.getHeader("Client-IP")).andReturn("127.0.0.1").anyTimes();
+
+        AttributeManager mockAttributeManager = PowerMock.createMock(AttributeManager.class);
+        EasyMock.expect(mockAttributeManager.isEphemeral("zimbraImapLoadBalancingAlgorithm")).andReturn(false).anyTimes();
+        EasyMock.expect(mockAttributeManager.getAttributeInfo("zimbraImapLoadBalancingAlgorithm")).andReturn(null).anyTimes();
+        Whitebox.setInternalState(config, "mAttrMgr", mockAttributeManager);
+
+        PowerMock.replayAll();
+
+        Server server = Whitebox.invokeMethod(mockHandler, "lookupUpstreamImapServer", mockRequest);
+        assertEquals("Server objects should be the same", testServer, server);
+
+        PowerMock.verifyAll();
+    }
+
+}

--- a/src/java-test/log4j-test.properties
+++ b/src/java-test/log4j-test.properties
@@ -1,0 +1,22 @@
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Server
+# Copyright (C) 2017 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+
+log4j.appender.stdout = org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout = org.apache.log4j.SimpleLayout
+log4j.org.apache.cassandra = INFO
+log4j.logger.zimbra.test=DEBUG
+#log4j.logger.zimbra.sqltrace=TRACE
+log4j.rootLogger = INFO,stdout
+log4j.logger.zimbra.elasticsearch=INFO

--- a/src/java/com/zimbra/cs/nginx/NginxLookupExtension.java
+++ b/src/java/com/zimbra/cs/nginx/NginxLookupExtension.java
@@ -119,6 +119,7 @@ public class NginxLookupExtension implements ZimbraExtension {
             // Expected in production, because JUnit is not available.
             ZimbraLog.test.debug("Unable to load TestClientUploader unit tests.", e);
         }
+
     }
 
     @Override
@@ -159,7 +160,7 @@ public class NginxLookupExtension implements ZimbraExtension {
         }
     }
 
-    private static class NginxLookupRequest {
+    public static class NginxLookupRequest {
         String user;
         String cuser;
         String pass;
@@ -758,7 +759,6 @@ public class NginxLookupExtension implements ZimbraExtension {
             cUser = req.cuser;              /* AUTHC (if GSSAPI) */
             qUser = aUser;                  /* Qualified AUTHZ (defaults to AUTHZ) */
 
-            Provisioning prov = Provisioning.getInstance();
             Account gssapiAuthC = null;
 
             if (req.authMethod.equalsIgnoreCase(AUTHMETH_ZIMBRAID)) {
@@ -880,13 +880,19 @@ public class NginxLookupExtension implements ZimbraExtension {
 
         private Server lookupUpstreamImapServer(NginxLookupRequest req) throws ServiceException {
             ImapLoadBalancingMechanism LBMech = ImapLoadBalancingMechanism.newInstance();
-            Server server = prov.getLocalServer();
-            String[] imapServerAddrs;
-            if (server != null) {
-                imapServerAddrs = server.getReverseProxyUpstreamImapServers();
-            } else {
-                imapServerAddrs = prov.getConfig().getReverseProxyUpstreamImapServers();
+            String[] imapServerAddrs = {};
+            Account acct = prov.get(AccountBy.name, req.user);
+            if (acct != null) {
+                Server server = acct.getServer();
+                if (server != null) {
+                    imapServerAddrs = server.getReverseProxyUpstreamImapServers();
+
+                    if (imapServerAddrs == null || imapServerAddrs.length == 0) {
+                        imapServerAddrs = new String[]{server.getServiceHostname()};
+                    }
+                }
             }
+
             List<Server> imapServers = new LinkedList<Server>();
             for (String host: imapServerAddrs) {
                 try {
@@ -908,7 +914,6 @@ public class NginxLookupExtension implements ZimbraExtension {
             try {
                 zlc = helper.getLdapContext();
 
-                Provisioning prov = Provisioning.getInstance();
                 Config config = prov.getConfig();
                 String authUser = getQualifiedUsername(zlc, config, req);
 


### PR DESCRIPTION
* Use the account's primary mailbox configured upstream imap servers if available
  Note: The provisioning code itself will fallback to the globally configured i
        items if mailbox specific setting is not found.
* Fallback to the local server if the previous call returns nothing

Note: Will be adding some unit tests to cover this code.  Wanted to get some eyeballs on the logic to make sure there are no objections.