### PR TITLE
ZCS-2971 - Correct IMAP port selection algorithm

### DIFF
--- a/src/java-test/com/zimbra/cs/account/UnitTestServer.java
+++ b/src/java-test/com/zimbra/cs/account/UnitTestServer.java
@@ -1,7 +1,5 @@
 package com.zimbra.cs.account;
 
-import com.zimbra.cs.account.Server;
-
 public class UnitTestServer extends Server {
     private String[] reverseProxyUpstreamImapServers = null;
     private String hostname = null;
@@ -25,5 +23,25 @@ public class UnitTestServer extends Server {
     public String toString()
     {
         return "UnitTestServer(" + this.hostname + ")";
+    }
+
+    @Override
+    public String getImapBindPortAsString() {
+        return "imap-internal";
+    }
+
+    @Override
+    public String getImapSSLBindPortAsString() {
+        return "imaps-internal";
+    }
+
+    @Override
+    public String getRemoteImapBindPortAsString() {
+        return "imap-remote";
+    }
+
+    @Override
+    public String getRemoteImapSSLBindPortAsString() {
+        return "imaps-remote";
     }
 }

--- a/src/java-test/com/zimbra/qa/unittest/NginxLookupExtensionTest.java
+++ b/src/java-test/com/zimbra/qa/unittest/NginxLookupExtensionTest.java
@@ -18,13 +18,20 @@
 package com.zimbra.qa.unittest;
 
 import com.zimbra.common.account.Key;
-import com.zimbra.cs.account.*;
+import com.zimbra.common.util.Pair;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AttributeManager;
 import com.zimbra.cs.account.Config;
 import com.zimbra.cs.account.Entry;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
+import com.zimbra.cs.account.UnitTestAccount;
+import com.zimbra.cs.account.UnitTestServer;
 import com.zimbra.cs.account.ldap.LdapProv;
 import com.zimbra.cs.account.ldap.LdapProvisioning;
 import com.zimbra.cs.imap.ImapLoadBalancingMechanism;
 import com.zimbra.cs.nginx.NginxLookupExtension;
+
 import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.Test;
@@ -97,7 +104,7 @@ public class NginxLookupExtensionTest extends TestCase {
 
         PowerMock.replayAll();
 
-        Server server = Whitebox.invokeMethod(handler, "lookupUpstreamImapServer", request);
+        Pair<Server, Boolean> server = Whitebox.invokeMethod(handler, "lookupUpstreamImapServer", request);
         assertEquals("Server objects should be null", null, server);
         PowerMock.verifyAll();
     }
@@ -139,8 +146,8 @@ public class NginxLookupExtensionTest extends TestCase {
 
         PowerMock.replayAll();
 
-        Server server = Whitebox.invokeMethod(handler, "lookupUpstreamImapServer", request);
-        assertEquals("Server objects should be the same", testServer, server);
+        Pair<Server, Boolean> server = Whitebox.invokeMethod(handler, "lookupUpstreamImapServer", request);
+        assertEquals("Server objects should be the same", testServer, server.getFirst());
 
         PowerMock.verifyAll();
     }
@@ -177,10 +184,28 @@ public class NginxLookupExtensionTest extends TestCase {
 
         PowerMock.replayAll();
 
-        Server server = Whitebox.invokeMethod(mockHandler, "lookupUpstreamImapServer", mockRequest);
-        assertEquals("Server objects should be the same", testServer, server);
+        Pair<Server, Boolean> server = Whitebox.invokeMethod(mockHandler, "lookupUpstreamImapServer", mockRequest);
+        assertEquals("Server objects should be the same", testServer, server.getFirst());
 
         PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testGetUpstreamIMAPPort() throws Exception {
+        NginxLookupExtension.NginxLookupHandler mockHandler = Whitebox.newInstance(NginxLookupExtension.NginxLookupHandler.class);
+        Server mockServer = Whitebox.newInstance(UnitTestServer.class);
+
+      // internal imap
+        String portString = Whitebox.invokeMethod(mockHandler, "getUpstreamIMAPPort", mockServer, "imap", false);
+        assertEquals("imap-internal", portString);
+        portString = Whitebox.invokeMethod(mockHandler, "getUpstreamIMAPPort", mockServer, "imaps", false);
+        assertEquals("imaps-internal", portString);
+
+        // remote imap
+        portString = Whitebox.invokeMethod(mockHandler, "getUpstreamIMAPPort", mockServer, "imap", true);
+        assertEquals("imap-remote", portString);
+        portString = Whitebox.invokeMethod(mockHandler, "getUpstreamIMAPPort", mockServer, "imaps", true);
+        assertEquals("imaps-remote", portString);
     }
 
 }

--- a/src/java/com/zimbra/cs/nginx/NginxLookupExtension.java
+++ b/src/java/com/zimbra/cs/nginx/NginxLookupExtension.java
@@ -49,6 +49,7 @@ import com.zimbra.common.account.ZAttrProvisioning.IPMode;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.Constants;
+import com.zimbra.common.util.Pair;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.AccessManager;
@@ -878,17 +879,29 @@ public class NginxLookupExtension implements ZimbraExtension {
             return domain;
         }
 
-        private Server lookupUpstreamImapServer(NginxLookupRequest req) throws ServiceException {
+        /**
+         * This function returns the most appropriate 'Server' to handle the IMAP request.
+         * It returns a pair of Server instance and a flag denoting if the Server is running IMAPD and IMAPD should
+         * be used to process the request.
+         * @param req
+         * @return Pair of Server, RemoteImapEnabled? where the second element is a boolean flag where true denotes Remote IMAP is to be used.
+         * @throws ServiceException
+         */
+        private Pair<Server, Boolean> lookupUpstreamImapServer(NginxLookupRequest req) throws ServiceException {
             ImapLoadBalancingMechanism LBMech = ImapLoadBalancingMechanism.newInstance();
+            HashMap<String, Boolean> servers = new HashMap<>();
             String[] imapServerAddrs = {};
             Account acct = prov.get(AccountBy.name, req.user);
             if (acct != null) {
                 Server server = acct.getServer();
                 if (server != null) {
                     imapServerAddrs = server.getReverseProxyUpstreamImapServers();
-
                     if (imapServerAddrs == null || imapServerAddrs.length == 0) {
                         imapServerAddrs = new String[]{server.getServiceHostname()};
+                        servers.put(server.getServiceHostname(), false);
+                    } else {
+                        // This 'Server' is configured to use Remote IMAPD.
+                        servers.put(server.getServiceHostname(), true);
                     }
                 }
             }
@@ -905,7 +918,16 @@ public class NginxLookupExtension implements ZimbraExtension {
             if (imapServers.isEmpty()) {
                 return null;
             } else {
-                return LBMech.getImapServerFromPool(req.httpReq, imapServers);
+                Server server = LBMech.getImapServerFromPool(req.httpReq, imapServers);
+                return new Pair<>(server, servers.get(server.getServiceHostname()));
+            }
+        }
+
+        private String getUpstreamIMAPPort(Server server, String proto, Boolean useRemoteImap) throws ServiceException {
+            if (useRemoteImap){
+                return proto.equals(IMAP) ? server.getRemoteImapBindPortAsString() : server.getRemoteImapSSLBindPortAsString();
+            } else {
+                return proto.equals(IMAP) ? server.getImapBindPortAsString() : server.getImapSSLBindPortAsString();
             }
         }
 
@@ -1045,15 +1067,14 @@ public class NginxLookupExtension implements ZimbraExtension {
 
                 //check to see if an IMAP request should be routed to an upstream IMAP server
                 if (req.proto.equals(IMAP) || req.proto.equals(IMAP_SSL)) {
-                    Server imapServer = lookupUpstreamImapServer(req);
+                    Pair<Server, Boolean> imapServer = lookupUpstreamImapServer(req);
+
                     if (imapServer != null) {
-                        String upstreamHost = imapServer.getServiceHostname();
+                        String upstreamHost = imapServer.getFirst().getServiceHostname();
                         if (doDnsLookup) {
                             upstreamHost = this.getIPByIPMode(upstreamHost).getHostAddress();
                         }
-                        String upstreamPort = req.proto.equals(IMAP) ?
-                                imapServer.getRemoteImapBindPortAsString() :
-                                imapServer.getRemoteImapSSLBindPortAsString();
+                        String upstreamPort = getUpstreamIMAPPort(imapServer.getFirst(), req.proto, imapServer.getSecond());
                         DomainExternalRouteInfo domain = getDomainExternalRouteInfo(zlc, config, authUserWithRealDomainName);
                         boolean extRouteIncludeOrigAuthuser = domain == null ?
                                 prov.getDefaultDomain().isReverseProxyExternalRouteIncludeOriginalAuthusername() :


### PR DESCRIPTION
The port selection was incorrectly always choosing the Remote IMAP service port instead of using the relevant configuration to choose whether or not to use the internal imap service instead.

This update tweaks the code to select based on the presence of imapd running on the node in addition to it being configured in the `zimbraReverseProxyUpstreamImapServers` attribute for the account's mailbox server.