### PR TITLE
ZCS-8017: updating guava version to 28.1-jre from 23.0 and centrally

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -18,7 +18,7 @@
   <dependency org="asm" name="asm" rev="3.3.1"/>
   <dependency org="dom4j" name="dom4j" rev="1.6.1"/>
   <dependency org="log4j" name="log4j" rev="1.2.17"/>
-  <dependency org="com.google.guava" name="guava" rev="23.0" />
+  <dependency org="com.google.guava" name="guava" rev="${com.google.guava.version}" />
   <dependency org="com.unboundid" name="unboundid-ldapsdk" rev="4.0.0"/>
   <dependency org="org.easymock" name="easymock" rev="3.4" />
   <dependency org="org.powermock" name="powermock-core" rev="1.7.1" />


### PR DESCRIPTION
Issue:
Vulnerabilities in older version 23.0 of Guava.

Fix:
Update version to 28.1-jre and make it available centrally