### PR TITLE
Zbug 3565- Need improvement in logging of auth requests

### DIFF
--- a/src/java/com/zimbra/cs/nginx/NginxLookupExtension.java
+++ b/src/java/com/zimbra/cs/nginx/NginxLookupExtension.java
@@ -1153,7 +1153,12 @@ public class NginxLookupExtension implements ZimbraExtension {
             DomainExternalRouteInfo domain =
                     getDomainExternalRouteInfo(zlc, config, authUserWithRealDomainName);
             if (domain == null || !domain.useExternalRouteIfAccountNotExist()) {
-                throw new EntryNotFoundException("user not found:" + authUserWithRealDomainName);
+                String errorMsg = "user not found:" + authUserWithRealDomainName;
+                if (LC.zimbra_additional_logging.booleanValue()) {
+                    errorMsg = "Error occurred during authentication: account not found for [" +  authUserWithRealDomainName + "]. oip=" + req.clientIp;
+                    ZimbraLog.security.info(errorMsg);
+                }
+                throw new EntryNotFoundException(errorMsg);
             }
 
             String mailhost = domain.getHostname(req.proto);


### PR DESCRIPTION

ZBUG-3565 - Need improvement in logging of auth requests in audit.log and mailbox.log 

Fix -  Fix - When the LC attribute zimbra_additional_logging is true  logging attempt   is logged to mailbox.log  and audit.log with IP for existing and non-existing account.